### PR TITLE
feat: add document upload page with progress indicator

### DIFF
--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -26,8 +26,12 @@ export default function LoginPage() {
       setLoading(true);
       await login(email, password);
       router.replace('/search');
-    } catch (err: any) {
-      setError(err.message || 'Login failed');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || 'Login failed');
+      } else {
+        setError('Login failed');
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -27,8 +27,12 @@ export default function RegisterPage() {
       await register(email, password);
       await login(email, password);
       router.replace('/search');
-    } catch (err: any) {
-      setError(err.message || 'Registration failed');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || 'Registration failed');
+      } else {
+        setError('Registration failed');
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import axios, { AxiosError } from 'axios';
+
+export default function UploadPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!file) {
+      setError('Please select a file');
+      return;
+    }
+    setError(null);
+    setSuccess(null);
+    setProgress(0);
+    try {
+      setUploading(true);
+      const token = localStorage.getItem('token');
+      const formData = new FormData();
+      formData.append('file', file);
+
+      await axios.post('http://localhost:8000/documents', formData, {
+        headers: {
+          Authorization: token ? `Bearer ${token}` : '',
+          'Content-Type': 'multipart/form-data',
+        },
+        onUploadProgress: (evt) => {
+          if (evt.total) {
+            setProgress(Math.round((evt.loaded * 100) / evt.total));
+          }
+        },
+      });
+
+      setSuccess('Uploaded! Ingestion queued.');
+      setFile(null);
+    } catch (err: unknown) {
+      const detail =
+        (err as AxiosError<{ detail?: string }>).response?.data?.detail;
+      setError(detail ?? 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto">
+      <h1 className="text-2xl mb-4">Upload</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        {progress !== null && <p>{progress}%</p>}
+        {success && <p className="text-green-500">{success}</p>}
+        {error && <p className="text-red-500">{error}</p>}
+        <button
+          type="submit"
+          disabled={uploading}
+          className="bg-blue-500 text-white p-2"
+        >
+          {uploading ? 'Uploading...' : 'Upload'}
+        </button>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add client-side upload page posting PDFs to backend and showing progress
- handle success/error banners and auth token
- replace explicit `any` types in auth forms

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689dd565a4b883218c51232dc1c01827