### PR TITLE
feat: add error banner and frontend docs

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,34 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Frontend
 
-## Getting Started
+## Installation
 
-First, run the development server:
+Install dependencies in this directory:
+
+```bash
+npm install
+```
+
+## Environment
+
+Copy `.env.local.example` to `.env.local` and set the backend API location:
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:8000
+```
+
+Adjust the URL if your API runs elsewhere and restart `npm run dev` after changes.
+
+## Development
+
+Start the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The app will be available at http://localhost:3000.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Troubleshooting
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- **CORS errors** – confirm the backend allows requests from the frontend origin.
+- **Wrong API URL** – ensure `NEXT_PUBLIC_API_URL` matches the backend.

--- a/frontend/app/documents/page.tsx
+++ b/frontend/app/documents/page.tsx
@@ -2,6 +2,7 @@
 
 import axios from 'axios';
 import { useCallback, useEffect, useState } from 'react';
+import { API_URL } from '@/lib/api';
 
 interface Document {
   id: string;
@@ -23,7 +24,7 @@ export default function DocumentsPage() {
 
   const fetchDocuments = useCallback(async () => {
     const token = localStorage.getItem('token');
-    const res = await axios.get<Document[]>('http://localhost:8000/documents', {
+    const res = await axios.get<Document[]>(`${API_URL}/documents`, {
       headers: { Authorization: token ? `Bearer ${token}` : '' },
     });
     setDocs(res.data);
@@ -37,7 +38,7 @@ export default function DocumentsPage() {
     const confirmed = window.confirm('Delete this document?');
     if (!confirmed) return;
     const token = localStorage.getItem('token');
-    await axios.delete(`http://localhost:8000/documents/${id}`, {
+    await axios.delete(`${API_URL}/documents/${id}`, {
       headers: { Authorization: token ? `Bearer ${token}` : '' },
     });
     fetchDocuments();

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -23,3 +23,19 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans);
 }
+
+@layer base {
+  input,
+  textarea,
+  select {
+    @apply border rounded px-3 py-2;
+  }
+
+  button {
+    @apply rounded px-3 py-2;
+  }
+
+  *:focus-visible {
+    @apply outline-none ring-2 ring-blue-500 ring-offset-2;
+  }
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { login } from '@/lib/auth';
+import ErrorBanner from '@/components/ErrorBanner';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -46,17 +47,15 @@ export default function LoginPage() {
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="border p-2"
         />
         <input
           type="password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="border p-2"
         />
-        {error && <p className="text-red-500">{error}</p>}
-        <button type="submit" disabled={loading} className="bg-blue-500 text-white p-2">
+        <ErrorBanner message={error} />
+        <button type="submit" disabled={loading} className="bg-blue-500 text-white">
           {loading ? 'Loading...' : 'Login'}
         </button>
       </form>

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { login, register } from '@/lib/auth';
+import ErrorBanner from '@/components/ErrorBanner';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -47,17 +48,15 @@ export default function RegisterPage() {
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="border p-2"
         />
         <input
           type="password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="border p-2"
         />
-        {error && <p className="text-red-500">{error}</p>}
-        <button type="submit" disabled={loading} className="bg-blue-500 text-white p-2">
+        <ErrorBanner message={error} />
+        <button type="submit" disabled={loading} className="bg-blue-500 text-white">
           {loading ? 'Loading...' : 'Register'}
         </button>
       </form>

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import axios, { AxiosError } from 'axios';
+import ErrorBanner from '@/components/ErrorBanner';
+import { API_URL } from '@/lib/api';
 
 interface SearchResult {
   document_id: string;
@@ -23,7 +25,7 @@ export default function SearchPage() {
     try {
       const token = localStorage.getItem('token');
       const res = await axios.post<SearchResult[] | { results: SearchResult[] }>(
-        'http://localhost:8000/search',
+        `${API_URL}/search`,
         { query, top_k: 10 },
         { headers: { Authorization: token ? `Bearer ${token}` : '' } }
       );
@@ -46,18 +48,18 @@ export default function SearchPage() {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="flex-grow border p-2"
+          className="flex-grow"
           placeholder="Enter query"
         />
         <button
           onClick={handleSearch}
           disabled={loading}
-          className="bg-blue-500 text-white px-4 py-2"
+          className="bg-blue-500 text-white"
         >
           {loading ? 'Searching...' : 'Search'}
         </button>
       </div>
-      {error && <p className="text-red-500">{error}</p>}
+      <ErrorBanner message={error} />
       <ul className="space-y-4">
         {results.map((hit) => (
           <li key={hit.document_id} className="border p-2">

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -2,6 +2,8 @@
 
 import { FormEvent, useState } from 'react';
 import axios, { AxiosError } from 'axios';
+import ErrorBanner from '@/components/ErrorBanner';
+import { API_URL } from '@/lib/api';
 
 export default function UploadPage() {
   const [file, setFile] = useState<File | null>(null);
@@ -25,7 +27,7 @@ export default function UploadPage() {
       const formData = new FormData();
       formData.append('file', file);
 
-      await axios.post('http://localhost:8000/documents', formData, {
+      await axios.post(`${API_URL}/documents`, formData, {
         headers: {
           Authorization: token ? `Bearer ${token}` : '',
           'Content-Type': 'multipart/form-data',
@@ -59,11 +61,11 @@ export default function UploadPage() {
         />
         {progress !== null && <p>{progress}%</p>}
         {success && <p className="text-green-500">{success}</p>}
-        {error && <p className="text-red-500">{error}</p>}
+        <ErrorBanner message={error} />
         <button
           type="submit"
           disabled={uploading}
-          className="bg-blue-500 text-white p-2"
+          className="bg-blue-500 text-white"
         >
           {uploading ? 'Uploading...' : 'Upload'}
         </button>

--- a/frontend/components/ErrorBanner.tsx
+++ b/frontend/components/ErrorBanner.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+interface ErrorBannerProps {
+  message: string | null;
+}
+
+export default function ErrorBanner({ message }: ErrorBannerProps) {
+  if (!message) return null;
+  return (
+    <div
+      role="alert"
+      className="bg-red-100 text-red-700 border border-red-300 rounded p-2"
+    >
+      {message}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,5 +1,7 @@
+import { API_URL } from '@/lib/api';
+
 export async function login(email: string, password: string): Promise<void> {
-  const res = await fetch('http://localhost:8000/auth/login', {
+  const res = await fetch(`${API_URL}/auth/login`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -14,7 +16,7 @@ export async function login(email: string, password: string): Promise<void> {
 }
 
 export async function register(email: string, password: string): Promise<void> {
-  const res = await fetch('http://localhost:8000/auth/register', {
+  const res = await fetch(`${API_URL}/auth/register`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- document setup and troubleshooting in frontend README
- add ErrorBanner for consistent error display and configurable API URL
- improve global form styles for better accessibility

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de43c8bb8832186c341ed9d4442d5