### PR TITLE
refactor: replace relative imports with absolute

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -6,8 +6,8 @@ from passlib.context import CryptContext
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
-from .db import get_db
-from .models import User
+from app.db import get_db
+from app.models import User
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")

--- a/app/main.py
+++ b/app/main.py
@@ -8,9 +8,9 @@ keep this file small and focused.
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .db import Base, engine
-from . import models  # ensure models are registered with SQLAlchemy
-from .routes import users, documents, search
+from app.db import Base, engine
+from app import models  # ensure models are registered with SQLAlchemy
+from app.routes import users, documents, search
 
 # Create tables on startup (for a real app alembic migrations are recommended)
 Base.metadata.create_all(bind=engine)

--- a/app/models.py
+++ b/app/models.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 
-from .db import Base
+from app.db import Base
 import uuid
 
 def gen_id() -> str:

--- a/app/routes/documents.py
+++ b/app/routes/documents.py
@@ -7,11 +7,11 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, status
 from sqlalchemy.orm import Session
 
-from ..auth import get_current_user
-from ..db import get_db
-from ..jobs import enqueue_ingest
-from ..models import Document, User
-from ..schemas import DocumentOut
+from app.auth import get_current_user
+from app.db import get_db
+from app.jobs import enqueue_ingest
+from app.models import Document, User
+from app.schemas import DocumentOut
 
 UPLOAD_ROOT = "/data/uploads"
 

--- a/app/routes/search.py
+++ b/app/routes/search.py
@@ -5,11 +5,11 @@ from typing import List
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from ..auth import get_current_user
-from ..db import get_db
-from ..embeddings import embed_text, cosine_similarity
-from ..models import Document, DocumentChunk, User
-from ..schemas import SearchRequest, SearchResult
+from app.auth import get_current_user
+from app.db import get_db
+from app.embeddings import embed_text, cosine_similarity
+from app.models import Document, DocumentChunk, User
+from app.schemas import SearchRequest, SearchResult
 
 router = APIRouter(tags=["search"])
 

--- a/app/routes/users.py
+++ b/app/routes/users.py
@@ -3,10 +3,10 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Form
 from sqlalchemy.orm import Session
 
-from ..db import get_db
-from ..models import User
-from ..schemas import UserCreate, UserOut, TokenOut
-from ..auth import (
+from app.db import get_db
+from app.models import User
+from app.schemas import UserCreate, UserOut, TokenOut
+from app.auth import (
     hash_password,
     verify_password,
     create_access_token,

--- a/app/worker.py
+++ b/app/worker.py
@@ -12,9 +12,9 @@ from typing import List
 
 from sqlalchemy.orm import Session
 
-from .db import SessionLocal
-from .embeddings import embed_text
-from .models import Document, DocumentChunk
+from app.db import SessionLocal
+from app.embeddings import embed_text
+from app.models import Document, DocumentChunk
 
 
 CHUNK_SIZE = 500  # characters per chunk for our toy ingestion


### PR DESCRIPTION
## Summary
- replace relative imports in backend modules with absolute imports

## Testing
- `pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689df436be308321a026738c6ab00ffb